### PR TITLE
String& to StringRef for Reactive<AudioProcessorValueTreeState>::parameterValue

### DIFF
--- a/reax/integration/reax_ModelExtensions.cpp
+++ b/reax/integration/reax_ModelExtensions.cpp
@@ -51,7 +51,7 @@ AudioProcessorValueTreeStateExtension::AudioProcessorValueTreeStateExtension(Aud
 
 AudioProcessorValueTreeStateExtension::~AudioProcessorValueTreeStateExtension() {}
 
-BehaviorSubject<var> AudioProcessorValueTreeStateExtension::parameterValue(const String& parameterID) const
+BehaviorSubject<var> AudioProcessorValueTreeStateExtension::parameterValue(StringRef parameterID) const
 {
     // Create a Reactive<Value> for the parameter, if not already done
     if (impl->parameterValues.find(parameterID) == impl->parameterValues.end())

--- a/reax/integration/reax_ModelExtensions.h
+++ b/reax/integration/reax_ModelExtensions.h
@@ -73,7 +73,7 @@ public:
      
      Parameter values can be changed from the audio thread; in this case the subject's `Observable` side emits asynchronously.
      */
-    BehaviorSubject<juce::var> parameterValue(const juce::String& parameterID) const;
+    BehaviorSubject<juce::var> parameterValue(const juce::StringRef parameterID) const;
     
 private:
     struct Impl;

--- a/reax/rx/internal/reax_Observable_Impl.cpp
+++ b/reax/rx/internal/reax_Observable_Impl.cpp
@@ -263,7 +263,8 @@ Subscription ObservableImpl::subscribe(const ObserverImpl& observer) const
             return any(0); \
     }
 
-ObservableImpl ObservableImpl::combineLatest(std::initializer_list<ObservableImpl> others, const any& function) const {
+ObservableImpl ObservableImpl::combineLatest(std::initializer_list<ObservableImpl> others, const any& function) const 
+{
     REAX_OBSERVABLE_IMPL_UNROLLED_LIST_IMPLEMENTATION_WITH_FUNCTION(combineLatest, others, function)
 }
 


### PR DESCRIPTION
So we can use `Identifier` as input to `parameterValue`, same as the underlying `AudioProcessorValueTreeState::parameterAsValue`

See #16 